### PR TITLE
feat: extend blacklisting

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,5 +6,5 @@ export const headers = {
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36",
 };
 
-export const SOURCE_NAME_BLACKLIST = ["CoinGeek"];
+export const SOURCE_NAME_BLACKLIST = ["coingeek", "fintech zoom"];
 export const TITLE_BLACKLIST = ["ripple", "xrp"];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,3 +5,6 @@ export const headers = {
   ["User-Agent"]:
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36",
 };
+
+export const SOURCE_NAME_BLACKLIST = ["CoinGeek"];
+export const TITLE_BLACKLIST = ["ripple", "xrp"];

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -2,17 +2,7 @@ import cheerio from "cheerio";
 import dedent from "dedent";
 
 import { News } from "~/src/types";
-import { HUMAN_TIME, SAFE_HTML as SH, TIMESTAMP } from "~/src/utils";
-
-const sourceNameBlacklist = ["CoinGeek"];
-const titleBlacklist = ["ripple", "xrp"];
-
-function blacklisted(sourceName: string, title: string) {
-  return (
-    sourceNameBlacklist.includes(sourceName) ||
-    titleBlacklist.some((bannedWord) => title.toLowerCase().includes(bannedWord))
-  );
-}
+import { HUMAN_TIME, SAFE_HTML as SH, TIMESTAMP, BLACKLISTED } from "~/src/utils";
 
 type Instruction = {
   links: { name: string; url: string; keywords: string[] }[];
@@ -36,7 +26,7 @@ export const GOOGLE_NEWS: Instruction = {
       const sourceUrl = `https://news.google.com${$(this).children("a").attr("href")?.slice(1)}`;
       const time = $(this).next("div").next("div").children("div").children("time").attr("datetime");
       const humanTime = HUMAN_TIME(time, -3);
-      if (title.match(/(Bitcoin|bitcoin|BTC|btc)/g) && !blacklisted(sourceName, title)) {
+      if (title.match(/(Bitcoin|bitcoin|BTC|btc)/g) && !BLACKLISTED(sourceName, title)) {
         news.push({
           title,
           sourceName,

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -5,9 +5,13 @@ import { News } from "~/src/types";
 import { HUMAN_TIME, SAFE_HTML as SH, TIMESTAMP } from "~/src/utils";
 
 const sourceNameBlacklist = ["CoinGeek"];
+const titleBlacklist = ["ripple", "xrp"];
 
-function blacklistedSource(sourceName: string) {
-  return sourceNameBlacklist.includes(sourceName);
+function blacklisted(sourceName: string, title: string) {
+  return (
+    sourceNameBlacklist.includes(sourceName) ||
+    titleBlacklist.some((bannedWord) => title.toLowerCase().includes(bannedWord))
+  );
 }
 
 type Instruction = {
@@ -32,7 +36,7 @@ export const GOOGLE_NEWS: Instruction = {
       const sourceUrl = `https://news.google.com${$(this).children("a").attr("href")?.slice(1)}`;
       const time = $(this).next("div").next("div").children("div").children("time").attr("datetime");
       const humanTime = HUMAN_TIME(time, -3);
-      if (title.match(/(Bitcoin|bitcoin|BTC|btc)/g) && !blacklistedSource(sourceName)) {
+      if (title.match(/(Bitcoin|bitcoin|BTC|btc)/g) && !blacklisted(sourceName, title)) {
         news.push({
           title,
           sourceName,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,7 @@ export const SILENT_TIME = (): boolean => {
 
 export const BLACKLISTED = (sourceName: string, title: string): boolean => {
   return (
-    SOURCE_NAME_BLACKLIST.includes(sourceName) ||
+    SOURCE_NAME_BLACKLIST.includes(sourceName.toLowerCase()) ||
     TITLE_BLACKLIST.some((bannedWord) => title.toLowerCase().includes(bannedWord))
   );
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import moment, { Moment } from "moment";
 
+import { SOURCE_NAME_BLACKLIST, TITLE_BLACKLIST } from "~/src/constants";
+
 export const CHUNK_ARRAY = (arr: any[], n): any[][] => {
   let i = 0;
   const ret: any[] = [];
@@ -46,4 +48,11 @@ export const SILENT_TIME = (): boolean => {
   } else {
     return false;
   }
+};
+
+export const BLACKLISTED = (sourceName: string, title: string): boolean => {
+  return (
+    SOURCE_NAME_BLACKLIST.includes(sourceName) ||
+    TITLE_BLACKLIST.some((bannedWord) => title.toLowerCase().includes(bannedWord))
+  );
 };


### PR DESCRIPTION
Agrega blacklisting simple por título: noticias cuyo título contenga alguna palabra de las de `TITLE_BLACKLIST` se filtrarán.

Además mejore un poco el orden moviendo  las blacklists a constants y la función a utils